### PR TITLE
Add restarter functions to avoid unbound exports.

### DIFF
--- a/nfiles.asd
+++ b/nfiles.asd
@@ -8,10 +8,7 @@
   :homepage "https://github.com/atlas-engineer/nfiles"
   :license "BSD 3-Clause"
   :in-order-to ((test-op (test-op "nfiles/tests")
-                         ;; Temporarily disabled until PR is merged
-                         ;; https://github.com/atlas-engineer/nfiles/issues/14
-                         ;; (test-op "nfiles/tests/compilation")
-                         ))
+                         (test-op "nfiles/tests/compilation")))
   :depends-on (alexandria
                #-(and sbcl (not android))
                iolib/os

--- a/package.lisp
+++ b/package.lisp
@@ -6,6 +6,7 @@
 (uiop:define-package nfiles
   (:use #:common-lisp #:nfiles/pathname)
   (:reexport #:nfiles/pathname)
+  (:shadow #:delete)                    ; TODO: Rename (and unshadow) with 2.0.0.
   (:import-from #:nclasses
                 #:define-class)
   (:import-from #:serapeum

--- a/readme.org
+++ b/readme.org
@@ -167,6 +167,11 @@ provide for interactive and customizable behaviour:
 - =process-error=: This may be raised for instance when =gpg= fails to encrypt.
   The =use-recipient= restart is provided to retry with the given recipient.
 
+** Shadowing
+
+NFiles 1 shadows =cl:delete=, thus you should not =:use= the package (as with
+any other library anyways).
+
 ** Platform support
 
 It's pure Common Lisp and all compilers plus all operating systems should be


### PR DESCRIPTION
Fixes #14.
Supersedes #19.

Discussions:

- I had to shadow `cl:delete`.  Can we do better?  If we rename `nfiles:delete` instead, it would be backward incompatible and thus we would have to release 2.0.0.

Thoughts?