### PR TITLE
Ensure consistent pathname return type in `resolve'.

### DIFF
--- a/nfiles.lisp
+++ b/nfiles.lisp
@@ -273,7 +273,7 @@ See `expand' for a convenience wrapper."))
   "Clean up the result before returning it."
   (let ((path (call-next-method)))
     (if (nil-pathname-p path)
-        path
+        #p""                         ; Ensure consistent `pathname' return type.
         (uiop:ensure-pathname path
                               :truenamize t))))
 


### PR DESCRIPTION
Fixes #23.